### PR TITLE
Feature preside xxx required if other field checked validation issue

### DIFF
--- a/services/validation/ValidationExtrasValidators.cfc
+++ b/services/validation/ValidationExtrasValidators.cfc
@@ -20,7 +20,7 @@
 		return arguments.data.keyExists( fieldName ) && !IsEmpty( value );
 	}
 	public string function requiredIfOtherFieldChecked_js() validatorMessage="cms:validation.required.default" {
-		return "function( value, el, params ){ $otherField = $( '[name=' + params[0] + ']' ); if ( !$otherField.length || !$otherField.is( ':checked' ) ) { return true; } return ( value.length > 0 ); }";
+		return "function( value, el, params ){ $otherField = $( '[name=' + params[0] + ']:checked' ); if ( !$otherField.length || !$otherField.is( ':checked' ) || ( params[1] != null && $otherField.val() != params[1] ) ) { return true; } return ( value.length > 0 ); }";
 	}
 
 


### PR DESCRIPTION
Currently if the validator added with params "otherField" and also"checkedValue", the validation js always return false even if the selected value of the "otherField" does not match the "checkedValue".

Updated to check if checkedValue (params[1]) provided and if the selected value of "otherField" matches the checkedValue, if yes the field is required, else it's not.
Example:
`<rule validator="requiredIfOtherFieldChecked">
	<param name="otherField" value="payment_options" />
	<param name="checkedValue" value="feeWaived" />
</rule>`
If payment_options != feeWaived, the field is not required.